### PR TITLE
Fix package.json (eg. by correcting repo URL)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,5 +21,7 @@
     "bluebird": "^2.6.4",
     "languages": "^0.1.3",
     "request": "^2.51.0"
-  }
+  },
+  "homepage": "https://github.com/Autarc/steam-store",
+  "bugs": "https://github.com/Autarc/steam-store/issues"
 }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/Autarc/material-ui-stylus.git"
+    "url": "https://github.com/Autarc/steam-store.git"
   },
   "license": "MIT",
   "author": "Stefan Dühring | Autarc <autarc@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,21 +1,9 @@
 {
   "name": "steam-store",
-  "version": "0.4.0",
   "description": "API client for the unofficial steam storefront/big picture resource",
-  "keywords": [
-    "steam",
-    "store",
-    "products",
-    "unofficial",
-    "API"
-  ],
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Autarc/steam-store.git"
-  },
-  "license": "MIT",
+  "version": "0.4.0",
   "author": "Stefan Dühring | Autarc <autarc@gmail.com>",
-  "main": "index.js",
+  "bugs": "https://github.com/Autarc/steam-store/issues",
   "dependencies": {
     "JSONStream": "^0.10.0",
     "bluebird": "^2.6.4",
@@ -23,5 +11,17 @@
     "request": "^2.51.0"
   },
   "homepage": "https://github.com/Autarc/steam-store",
-  "bugs": "https://github.com/Autarc/steam-store/issues"
+  "keywords": [
+    "steam",
+    "store",
+    "products",
+    "unofficial",
+    "API"
+  ],
+  "license": "MIT",
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Autarc/steam-store.git"
+  }
 }


### PR DESCRIPTION
# This PR...
- ...adds _homepage_ and _issues_ fields to `package.json`, as is a recommended practise.
- ...[fixpacks](https://github.com/HenrikJoreteg/fixpack) the whole `package.json` (just an added bonus)
- ...and most of all, correct the repo URL, 'cause this is just plain confusing:

![screen shot 2015-01-27 at 19 05 34](https://cloud.githubusercontent.com/assets/1321686/5922882/ca62a8c8-a657-11e4-98b1-15a94222e721.png)

And yeah, the real reason for this PR was really just the WTF moment when I tried to enter the GitHub page via npmjs.org, and got something Material UI stuff instead :smiley_cat: 
